### PR TITLE
Fix: prevent history file corruption with concurrent sessions

### DIFF
--- a/plugin/history.bash
+++ b/plugin/history.bash
@@ -2,13 +2,42 @@
 # History
 ################################################################################
 
-# Clean-up history file
+# Clean-up history file (deduplicate)
+__cleanup_history() {
+	[ -n "$HISTFILE" ] && [ -f "$HISTFILE" ] || return 0
+
+	local lockdir="${HISTFILE}.lock"
+	local tmpfile
+
+	# Remove stale lock older than 60 seconds
+	if [ -d "$lockdir" ]; then
+		find "$lockdir" -maxdepth 0 -mmin +1 -exec rmdir {} \; 2>/dev/null
+	fi
+
+	# Try to acquire lock
+	mkdir "$lockdir" 2>/dev/null || return 0
+	trap 'rmdir "$lockdir" 2>/dev/null' EXIT
+
+	# Deduplicate history, preserving timestamps
+	tmpfile=$(mktemp "${HISTFILE}.XXXXXX")
+	nl "$HISTFILE" | sort -rn | sort -uk2 | sort -nk1 | cut -f2- | \
+		awk '/^#[0-9]+$/ { ts=$0; next } { if (ts) print ts; ts=""; if (NF) print }' > "$tmpfile"
+
+	# Only replace if result is non-empty
+	if [ -s "$tmpfile" ]; then
+		mv "$tmpfile" "$HISTFILE"
+	else
+		rm -f "$tmpfile"
+	fi
+
+	# Release lock
+	rmdir "$lockdir" 2>/dev/null
+	trap - EXIT
+}
+
+# Run cleanup on interactive shell startup
 if [ "${-#*i}" != "$-" ]; then
-	TMPFILE=$(mktemp)
-	nl $HISTFILE | sort -rn | sort -uk2 | sort -nk1 | cut -f2- | \
-		awk '/^#[0-9]+$/ { ts=$0; next } { if (ts) print ts; ts=""; if (NF) print }' > $TMPFILE
-	cp $TMPFILE $HISTFILE
-	rm $TMPFILE
+	__cleanup_history
 fi
 
 # Try to save multiple lines cmd to one history entry


### PR DESCRIPTION
- Add mkdir-based locking (portable across Linux/macOS/Git Bash)
- Use atomic mv instead of cp for file replacement
- Guard against replacing history with empty file
- Add stale lock detection (removes locks older than 60s)
- Wrap cleanup logic in __cleanup_history function